### PR TITLE
Switch to lazy static initialization for the element table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2018"
 name="periodic_table"
 path="src/lib.rs"
 
+[dependencies]
+lazy_static = "1.4"
+
 [build-dependencies]
 csv = "1.1"
 handlebars = "2.0"

--- a/build.rs
+++ b/build.rs
@@ -141,8 +141,6 @@ fn init_templating() -> Handlebars {
 }
 
 /// Generate the lib.rs file with an element list
-/// TODO: Maybe this list can be a static array?
-/// TODO: Maybe use lazy_static! ?
 fn main() -> Result<(), Box<dyn Error>> {
     let src_path = "lib.rs.tpl";
     let dest_path = "src/lib.rs";

--- a/lib.rs.tpl
+++ b/lib.rs.tpl
@@ -1,14 +1,16 @@
 // This file is auto generated. Modify build.rs instead of this file
 pub use element::{Element, IonRadius, State, Year};
 
+use lazy_static::lazy_static;
+
 mod element;
 #[cfg(test)]
 mod test;
 
-/// Return a list of elements in the periodic table
-pub fn periodic_table() -> Vec<Element> {
-    vec![
-        {{#each elements}}Element {
+lazy_static! {
+    /// The list of elements in the periodic table
+    static ref PERIODIC_TABLE: Vec<Element> = vec![{{#each elements}}
+        Element {
             atomic_number: {{atomic_number}},
             symbol: {{str symbol}},
             name: {{str name}},
@@ -29,7 +31,11 @@ pub fn periodic_table() -> Vec<Element> {
             density: {{option_f32 density}},
             group_block: {{str group_block}},
             year_discovered: {{year year_discovered}},
-        },
-        {{/each}}
-    ]
+        },{{/each}}
+    ];
+}
+
+/// Return a list of elements in the periodic table
+pub fn periodic_table() -> &'static [Element] {
+    &PERIODIC_TABLE
 }


### PR DESCRIPTION
This turns the element table into a lazy static Vec, and modifies the public function to rely on it.
In order to avoid exposing a Vec or a lazy_static internal type, the function returns a slice directly.

Note that we cannot return a Vec directly because it would need to move out of the static.
To make it work, we'd need to clone the Vec instead, which would defeat the purpose of using a static variable in the first place.