### PR TITLE
Improve code generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 **/*.rs.bk
 Cargo.lock
-src/lib.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,6 @@ license = "MIT"
 repository = "https://github.com/trangar/periodic_table"
 edition = "2018"
 
-[lib]
-name="periodic_table"
-path="src/lib.rs"
-
 [build-dependencies]
 askama = "0.8"
 csv = "1.1"

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@
 
 use askama::Template;
 use serde::Deserialize;
-use std::{error::Error, fs::File, io::Write};
+use std::{env, error::Error, fs::File, io::Write, path::Path};
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all(deserialize = "camelCase"))]
@@ -30,7 +30,7 @@ struct Record {
 }
 
 #[derive(Template)]
-#[template(path = "lib.rs", escape = "none")]
+#[template(path = "elements.rs", escape = "none")]
 struct Data {
     elements: Vec<Record>,
 }
@@ -109,7 +109,8 @@ mod filters {
 
 /// Generate the lib.txt file with an element list
 fn main() -> Result<(), Box<dyn Error>> {
-    let dest_path = "src/lib.rs";
+    let out_dir = env::var("OUT_DIR")?;
+    let dest_path = Path::new(&out_dir).join("elements.rs");
 
     // create CSV reader
     let mut reader = csv::ReaderBuilder::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,16 @@
+#![deny(clippy::pedantic, clippy::indexing_slicing)]
+#![allow(clippy::unreadable_literal)]
+#![cfg_attr(not(test), no_std)]
+
+pub use element::{Element, IonRadius, State, Year};
+
+mod element;
+#[cfg(test)]
+mod test;
+
+include!(concat!(env!("OUT_DIR"), "/elements.rs"));
+
+/// Return a list of elements in the periodic table
+pub fn periodic_table() -> &'static [&'static Element] {
+    &PERIODIC_TABLE
+}

--- a/templates/elements.rs
+++ b/templates/elements.rs
@@ -1,15 +1,3 @@
-// This file is auto generated. Modify build.rs instead of this file
-#![deny(clippy::pedantic, clippy::indexing_slicing)]
-#![allow(clippy::unreadable_literal)]
-
-#![cfg_attr(not(test), no_std)]
-
-pub use element::{Element, IonRadius, State, Year};
-
-mod element;
-#[cfg(test)]
-mod test;
-
 /// The list of elements in the periodic table
 static PERIODIC_TABLE: &[&Element] = &[{% for e in elements %}
     &Element {
@@ -35,8 +23,3 @@ static PERIODIC_TABLE: &[&Element] = &[{% for e in elements %}
         year_discovered: {{ e.year_discovered|year }},
     },{% endfor %}
 ];
-
-/// Return a list of elements in the periodic table
-pub fn periodic_table() -> &'static [&'static Element] {
-    &PERIODIC_TABLE
-}


### PR DESCRIPTION
This makes sure no file under src is modified dynamically.
This allows us to avoid getting warnings when publishing the crate.

Note that all configuration directives must be physically present at the beginning of a source file, so leaving them in the included _elements.rs_ file causes compilation errors.